### PR TITLE
Feature/server spin up

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,4 +7,4 @@ ADD yarn.lock .
 
 RUN yarn install
 
-WORKDIR /usr/ph-todo-frontend/build
+WORKDIR /usr/ph-todo-frontend/build/server-assets

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.14.0",
     "helmet": "^3.4.0",
     "jquery": "^3.1.1",
+    "morgan": "^1.7.0",
     "q": "^1.4.1",
     "seneca": "^3.2.2",
     "seneca-amqp-transport": "^2.1.0",

--- a/src/server-assets/app.coffee
+++ b/src/server-assets/app.coffee
@@ -1,0 +1,18 @@
+express = require 'express'
+helmet = require 'helmet'
+morgan = require 'morgan'
+
+# Instantiate the express app
+app = express()
+
+# Log Requests to the server
+app.use morgan 'dev'
+
+# Protect ourselves
+app.use helmet()
+
+# Send only the client folder for requests to the server
+app.use '/', express.static "#{__dirname}/../client"
+
+# Export the app for use in the server
+module.exports = app

--- a/src/server-assets/server.coffee
+++ b/src/server-assets/server.coffee
@@ -1,0 +1,18 @@
+act = require "#{__dirname}/seneca/act"
+app = require "#{__dirname}/app"
+
+port = 80
+version = process.env.PH_FRONTEND_V
+server = app.listen port, (err)->
+  if err
+    console.log 'Error starting API server', err
+  else
+    log_opts =
+      role: 'util'
+      cmd: 'log'
+      type: 'general'
+      service: 'Frontend Server'
+      message: "Frontend Server v#{version} started on port #{port}"
+    act log_opts
+
+module.exports = server

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,10 @@ backoff@~2.5.0:
   dependencies:
     precond "0.2"
 
+basic-auth@~1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.0.4.tgz#030935b01de7c9b94a824b29f3fccb750d3a5290"
+
 bitsyntax@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/bitsyntax/-/bitsyntax-0.0.4.tgz#eb10cc6f82b8c490e3e85698f07e83d46e0cba82"
@@ -373,6 +377,16 @@ minimist@1.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+morgan@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.7.0.tgz#eb10ca8e50d1abe0f8d3dad5c0201d052d981c62"
+  dependencies:
+    basic-auth "~1.0.3"
+    debug "~2.2.0"
+    depd "~1.1.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -413,6 +427,10 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 ordu@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
The server can spin up and log its version with the worker:util plugin.
<img width="404" alt="screen shot 2017-02-01 at 9 25 43 am" src="https://cloud.githubusercontent.com/assets/9676018/22518257/d70c0964-e860-11e6-99fa-c810e0b96c9f.png">